### PR TITLE
(Lavaplayer) Check track.sourceManager.sourceName to support non-default source managers

### DIFF
--- a/lavaplayer/src/main/kotlin/LavaplayerUtil.kt
+++ b/lavaplayer/src/main/kotlin/LavaplayerUtil.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletionStage
 @JvmName("findLyricsSuspending")
 public suspend fun LyricsClient.findLyrics(track: AudioTrack): Lyrics {
     val videoId = when {
-        track is YoutubeAudioTrack -> track.info.identifier
+        track.sourceManager.sourceName == "youtube" -> track.info.identifier
         track.info.isrc != null -> search(track.info.isrc).firstOrNull()?.videoId ?: throw LyricsNotFoundException()
         else -> search("${track.info.title} - ${track.info.author}").firstOrNull()?.videoId
             ?: throw LyricsNotFoundException()

--- a/lavaplayer/src/main/kotlin/LavaplayerUtil.kt
+++ b/lavaplayer/src/main/kotlin/LavaplayerUtil.kt
@@ -2,7 +2,6 @@
 
 package dev.schlaubi.lyrics.lavaplayer
 
-import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import dev.schlaubi.lyrics.LyricsClient
 import dev.schlaubi.lyrics.LyricsNotFoundException


### PR DESCRIPTION
Fixes an issue where the track identifier wouldn't be used if the track wasn't a default `YoutubeAudioTrack`, typically from non-standard source manager implementations